### PR TITLE
engraph: can you add a sales table to the project please?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 dbt_modules/
 logs/
 **/.DS_Store
+profiles.yml
+.user.yml

--- a/models/sales.sql
+++ b/models/sales.sql
@@ -1,0 +1,10 @@
+with sales as (
+    select
+        o.*,
+        p.AMOUNT
+    from {{ ref('orders') }} as o
+    join {{ ref('stg_payments') }} as p
+        on o.ORDER_ID = p.ORDER_ID
+)
+
+select * from sales

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -80,3 +80,109 @@ models:
         description: Amount of the order (AUD) paid for by gift card
         tests:
           - not_null
+version: 2
+
+models:
+  - name: customers
+    description: This table has basic information about a customer, as well as some derived facts based on a customer's orders
+
+    columns:
+      - name: customer_id
+        description: This is a unique identifier for a customer
+        tests:
+          - unique
+          - not_null
+
+      - name: first_name
+        description: Customer's first name. PII.
+
+      - name: last_name
+        description: Customer's last name. PII.
+
+      - name: first_order
+        description: Date (UTC) of a customer's first order
+
+      - name: most_recent_order
+        description: Date (UTC) of a customer's most recent order
+
+      - name: number_of_orders
+        description: Count of the number of orders a customer has placed
+
+      - name: total_order_amount
+        description: Total value (AUD) of a customer's orders
+
+  - name: orders
+    description: This table has basic information about orders, as well as some derived facts based on payments
+
+    columns:
+      - name: order_id
+        tests:
+          - unique
+          - not_null
+        description: This is a unique identifier for an order
+
+      - name: customer_id
+        description: Foreign key to the customers table
+        tests:
+          - not_null
+          - relationships:
+              to: ref('customers')
+              field: customer_id
+
+      - name: order_date
+        description: Date (UTC) that the order was placed
+
+      - name: status
+        description: '{{ doc("orders_status") }}'
+        tests:
+          - accepted_values:
+              values: ['placed', 'shipped', 'completed', 'return_pending', 'returned']
+
+      - name: amount
+        description: Total amount (AUD) of the order
+        tests:
+          - not_null
+
+      - name: credit_card_amount
+        description: Amount of the order (AUD) paid for by credit card
+        tests:
+          - not_null
+
+      - name: coupon_amount
+        description: Amount of the order (AUD) paid for by coupon
+        tests:
+          - not_null
+
+      - name: bank_transfer_amount
+        description: Amount of the order (AUD) paid for by bank transfer
+        tests:
+          - not_null
+
+      - name: gift_card_amount
+        description: Amount of the order (AUD) paid for by gift card
+        tests:
+          - not_null
+
+models:
+  - name: sales
+    description: This model combines the orders and stg_payments models, joining them on the ORDER_ID column.
+    columns:
+      - name: ORDER_ID
+        description: The unique identifier for each order.
+        tests:
+          - unique
+          - not_null
+      - name: CUSTOMER_ID
+        description: The unique identifier for each customer.
+        tests:
+          - not_null
+      - name: ORDER_DATE
+        description: The date the order was placed.
+        tests:
+          - not_null
+      - name: STATUS
+        description: The current status of the order.
+      - name: AMOUNT
+        description: The amount paid for the order.
+        tests:
+          - not_null


### PR DESCRIPTION
I have created a sales table that combines information from the orders and stg_payments models. The new model is called sales and is saved as model.jaffle_shop.sales.