### PR TITLE
engraph: can you add a table of the best ranking salespeople to the database?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 dbt_modules/
 logs/
 **/.DS_Store
+profiles.yml
+.user.yml


### PR DESCRIPTION
{
    "is_possible": false,
    "explanation": "The current dbt project does not contain any information about salespeople, so it is not possible to add a table of the best ranking salespeople to the database.",
}