### PR TITLE
engraph: can you add a sales table to the dbt project?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 dbt_modules/
 logs/
 **/.DS_Store
+profiles.yml
+.user.yml

--- a/models/sales.sql
+++ b/models/sales.sql
@@ -1,0 +1,22 @@
+with orders as (
+        select * from {{ ref('stg_orders') }}
+    ),
+    customers as (
+        select * from {{ ref('stg_customers') }}
+    ),
+    payments as (
+        select * from {{ ref('stg_payments') }}
+    )
+    select
+        orders.order_id,
+        orders.customer_id,
+        orders.order_date,
+        orders.status,
+        customers.first_name,
+        customers.last_name,
+        payments.payment_id,
+        payments.payment_method,
+        payments.amount
+    from orders
+    join customers on orders.customer_id = customers.customer_id
+    join payments on orders.order_id = payments.order_id


### PR DESCRIPTION
{
    "is_possible": true,
    "explanation": "I have created a sales table by joining the stg_orders, stg_customers, and stg_payments models on their respective keys (order_id and customer_id). The sales table includes all columns from the three models and is saved as model.jaffle_shop.sales.",
}