### PR TITLE
engraph: can you build a sales table please

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 dbt_modules/
 logs/
 **/.DS_Store
+profiles.yml
+.user.yml

--- a/models/sales.sql
+++ b/models/sales.sql
@@ -1,0 +1,28 @@
+{{
+    config(materialized='table')
+}}
+
+with orders as (
+    select
+        order_id,
+        customer_id,
+        order_date
+    from {{ ref('stg_orders') }}
+),
+
+payments as (
+    select
+        order_id,
+        payment_method,
+        amount
+    from {{ ref('stg_payments') }}
+)
+
+select
+    o.customer_id,
+    o.order_date,
+    p.payment_method,
+    p.amount
+from orders o
+join payments p
+    on o.order_id = p.order_id

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -80,3 +80,109 @@ models:
         description: Amount of the order (AUD) paid for by gift card
         tests:
           - not_null
+version: 2
+
+models:
+  - name: customers
+    description: This table has basic information about a customer, as well as some derived facts based on a customer's orders
+
+    columns:
+      - name: customer_id
+        description: This is a unique identifier for a customer
+        tests:
+          - unique
+          - not_null
+
+      - name: first_name
+        description: Customer's first name. PII.
+
+      - name: last_name
+        description: Customer's last name. PII.
+
+      - name: first_order
+        description: Date (UTC) of a customer's first order
+
+      - name: most_recent_order
+        description: Date (UTC) of a customer's most recent order
+
+      - name: number_of_orders
+        description: Count of the number of orders a customer has placed
+
+      - name: total_order_amount
+        description: Total value (AUD) of a customer's orders
+
+  - name: orders
+    description: This table has basic information about orders, as well as some derived facts based on payments
+
+    columns:
+      - name: order_id
+        tests:
+          - unique
+          - not_null
+        description: This is a unique identifier for an order
+
+      - name: customer_id
+        description: Foreign key to the customers table
+        tests:
+          - not_null
+          - relationships:
+              to: ref('customers')
+              field: customer_id
+
+      - name: order_date
+        description: Date (UTC) that the order was placed
+
+      - name: status
+        description: '{{ doc("orders_status") }}'
+        tests:
+          - accepted_values:
+              values: ['placed', 'shipped', 'completed', 'return_pending', 'returned']
+
+      - name: amount
+        description: Total amount (AUD) of the order
+        tests:
+          - not_null
+
+      - name: credit_card_amount
+        description: Amount of the order (AUD) paid for by credit card
+        tests:
+          - not_null
+
+      - name: coupon_amount
+        description: Amount of the order (AUD) paid for by coupon
+        tests:
+          - not_null
+
+      - name: bank_transfer_amount
+        description: Amount of the order (AUD) paid for by bank transfer
+        tests:
+          - not_null
+
+      - name: gift_card_amount
+        description: Amount of the order (AUD) paid for by gift card
+        tests:
+          - not_null
+
+version: 2
+
+models:
+  - name: sales
+    description: This table joins stg_orders and stg_payments on the ORDER_ID column and includes CUSTOMER_ID, ORDER_DATE, PAYMENT_METHOD, and AMOUNT.
+    columns:
+      - name: customer_id
+        description: The ID of the customer who placed the order
+        tests:
+          - not_null
+          - unique
+      - name: order_date
+        description: The date the order was placed
+        tests:
+          - not_null
+      - name: payment_method
+        description: The method of payment used for the order
+        tests:
+          - not_null
+      - name: amount
+        description: The amount of the order in dollars
+        tests:
+          - not_null


### PR DESCRIPTION
I have successfully created a sales table by joining the stg_orders and stg_payments models on the ORDER_ID column. The resulting table includes the required columns: CUSTOMER_ID, ORDER_DATE, PAYMENT_METHOD, and AMOUNT. The new model is saved as model.jaffle_shop.sales.