### PR TITLE
engraph: can you please add a sales table to the project?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 dbt_modules/
 logs/
 **/.DS_Store
+profiles.yml
+.user.yml

--- a/models/sales.sql
+++ b/models/sales.sql
@@ -1,0 +1,34 @@
+{{
+    config(materialized='table')
+}}
+
+with orders as (
+    select * from {{ ref('stg_orders') }}
+),
+
+payments as (
+    select * from {{ ref('stg_payments') }}
+),
+
+joined_data as (
+    select
+        o.order_id,
+        o.customer_id,
+        o.order_date,
+        o.status,
+        p.payment_id,
+        p.payment_method,
+        p.amount
+    from orders o
+    join payments p on o.order_id = p.order_id
+),
+
+sales_data as (
+    select
+        order_id,
+        sum(amount) as sales
+    from joined_data
+    group by order_id
+)
+
+select * from sales_data


### PR DESCRIPTION
I have created a new model named 'model.jaffle_shop.sales' that calculates sales by joining the stg_orders and stg_payments models on the order_id column and summing the amount column from stg_payments. The sales table has been added to the project.